### PR TITLE
Remove constructors from TS SDK models

### DIFF
--- a/src/sdk/models/shared/security.ts
+++ b/src/sdk/models/shared/security.ts
@@ -1,22 +1,15 @@
-import {Metadata} from "../../../internal/utils/utils";
+import { Base, Model, Primed } from "primed-model";
+import { Metadata } from "../../../internal/utils/utils";
 
-export class SchemeApiKey {
-    @Metadata("security, name=x-api-key")
-    ApiKey: string;
-    
-    constructor(ApiKey: string) {
-		this.ApiKey = ApiKey;
-	}
+@Model
+export class SchemeApiKey extends Base<SchemeApiKey> {
+  @Metadata("security, name=x-api-key")
+  ApiKey: string;
 }
 
-export class Security {
-    @Metadata("security, scheme=true;type=apiKey;subtype=header")
-    ApiKey: SchemeApiKey;
-    
-    constructor(ApiKey: SchemeApiKey) {
-		this.ApiKey = ApiKey;
-	}
+@Model
+export class Security extends Base<Security> {
+  @Metadata("security, scheme=true;type=apiKey;subtype=header")
+  @Primed(SchemeApiKey)
+  ApiKey: SchemeApiKey;
 }
-
-
-


### PR DESCRIPTION
Will close this PR, opened just to showcase attempt at removing constructor bloat. Reference article: https://dev.to/cuzox/dynamically-convert-plain-objects-into-typescript-classes-1cjg

Initially copied `Base` class definition along with Indexable, Constructor, and DeepPartial types. This wasn't sufficient, and from the article, `Model` is required to do the actual overriding of the constructor with `init`. When I tried using all of these without `Primed`, it turned out:
```
Object.getOwnPropertyNames(security) == [];
```
So this is wrong and won't allow me to index the top-level type (`Security`) to start iterating through the `SchemeApiKey` fields.

I eventually just ended up importing `primed-model` to see if I could get it working using all of Base, Model, and Primed as displayed in this PR. I found that the properties are displayed for the top-level type, but not the inner type. Hence:
```
Object.getOwnPropertyNames(security) == ['ApiKey'];
Object.getOwnPropertyNames(security['ApiKey']) == [];
```

These are the initialization procedures I've tried for the security type.
- `const security: Security = new Security({ApiKey: new SchemeApiKey({ApiKey: "XXXXXX"})});`
- `const security: Security = new Security({ApiKey: {ApiKey: "XXXXXX"}});`
And also separating the assignment in to multiple variables:
```
const apiKey: SchemeApiKey = new SchemeApiKey({ApiKey: "XXXXXX"});
const security: Security = new Security({ApiKey: apiKey});
```

But these all yield the same results. Any thoughts?
