### PR TITLE
refactor: replace for-of with for-await-of in hook iterations

### DIFF
--- a/src/hooks/hooks.ts
+++ b/src/hooks/hooks.ts
@@ -93,7 +93,7 @@ export class SDKHooks implements Hooks {
   ): Promise<Request> {
     let req = request;
 
-    for (const hook of this.beforeRequestHooks) {
+    for await (const hook of this.beforeRequestHooks) {
       req = await hook.beforeRequest(hookCtx, req);
     }
 
@@ -106,7 +106,7 @@ export class SDKHooks implements Hooks {
   ): Promise<Response> {
     let res = response;
 
-    for (const hook of this.afterSuccessHooks) {
+    for await (const hook of this.afterSuccessHooks) {
       res = await hook.afterSuccess(hookCtx, res);
     }
 
@@ -121,7 +121,7 @@ export class SDKHooks implements Hooks {
     let res = response;
     let err = error;
 
-    for (const hook of this.afterErrorHooks) {
+    for await (const hook of this.afterErrorHooks) {
       const result = await hook.afterError(hookCtx, res, err);
       res = result.response;
       err = result.error;

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -52,7 +52,7 @@ export class HTTPClient {
 
   async request(request: Request): Promise<Response> {
     let req = request;
-    for (const hook of this.requestHooks) {
+    for await (const hook of this.requestHooks) {
       const nextRequest = await hook(req);
       if (nextRequest) {
         req = nextRequest;
@@ -62,13 +62,13 @@ export class HTTPClient {
     try {
       const res = await this.fetcher(req);
 
-      for (const hook of this.responseHooks) {
+      for await (const hook of this.responseHooks) {
         await hook(res, req);
       }
 
       return res;
     } catch (err) {
-      for (const hook of this.requestErrorHooks) {
+      for await (const hook of this.requestErrorHooks) {
         await hook(err, req);
       }
 


### PR DESCRIPTION
Replace for-of with for-await-of in hook iteration to properly handle async hooks.

This change ensures that each hook is properly awaited before proceeding to the next one, which is the correct behavior for sequential hook processing where order matters.